### PR TITLE
cdvfile:// URLs handling support

### DIFF
--- a/src/android/com/fgomiero/cordova/plugin/ExternalFileUtil.java
+++ b/src/android/com/fgomiero/cordova/plugin/ExternalFileUtil.java
@@ -44,7 +44,10 @@ public class ExternalFileUtil extends CordovaPlugin {
 	 */
 	private void openFile(String url) throws IOException {
 		// Create URI
-		Uri uri = Uri.parse(url);
+		final CordovaResourceApi resourceApi = webView.getResourceApi();
+
+		Uri tmpTarget = Uri.parse(url);
+		final Uri uri = resourceApi.remapUri(tmpTarget.getScheme() != null ? tmpTarget : Uri.fromFile(new File(url)));
 
 		Intent intent = null;
 		// Check what kind of file you are trying to open, by comparing the url with extensions.


### PR DESCRIPTION
Support for latest Cordova File API v1.0 with file URL styled as "cdvfile://"

https://github.com/apache/cordova-plugin-file/blob/dev/doc/index.md#upgrading-notes
